### PR TITLE
feat Article 수정 시 이미지 로직 기능 변경

### DIFF
--- a/src/main/java/com/example/oneinkedoneproject/service/article/ArticleService.java
+++ b/src/main/java/com/example/oneinkedoneproject/service/article/ArticleService.java
@@ -108,7 +108,8 @@ public class ArticleService {
 
         // 1. Article 생성
         updatedArticle.update(contents);
-
+        imageRepository.deleteByArticleId(updatedArticle.getId());
+        updatedArticle.getImageList().clear();
         List<Image> images = new ArrayList<>();
         if (updateArticleRequestDto.getFiles() != null && !updateArticleRequestDto.getFiles().isEmpty()) {
             try {

--- a/src/test/java/com/example/oneinkedoneproject/controller/ArticleControllerUnitTest.java
+++ b/src/test/java/com/example/oneinkedoneproject/controller/ArticleControllerUnitTest.java
@@ -161,10 +161,11 @@ public class ArticleControllerUnitTest {
         List<MultipartFile> updatedfiles = new ArrayList<>();
         updatedfiles.add(file);
         updatedfiles.add(file1);
+
         List<Image> updatedimages = new ArrayList<>();
         for (MultipartFile fileImage : updatedfiles) {
             Image image = Image.builder()
-                    .img(fileImage.getBytes())
+                    .img(fileImage.getBytes()).article(article)
                     .build();
             updatedimages.add(image);
         }

--- a/src/test/java/com/example/oneinkedoneproject/controller/ArticleIntegratedTest.java
+++ b/src/test/java/com/example/oneinkedoneproject/controller/ArticleIntegratedTest.java
@@ -227,7 +227,7 @@ public class ArticleIntegratedTest {
         Article updatedArticle = articleRepository.findById(article.getId())
                 .orElseThrow();
 
-        assertThat(updatedArticle.getImageList().size()).isEqualTo(3);
+        assertThat(updatedArticle.getImageList().size()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
1. 기존: Article 수정할 때 기존 이미지에 더해 유저가 보낸 이미지까지 추가
-> 유저가 보낸 새로운 이미지가 있으면 기존 이미지 전부 삭제하고 새로운 이미지로 대체

#123 